### PR TITLE
Remove APSIS domains from the list

### DIFF
--- a/Swedish List for Adblock Plus.txt
+++ b/Swedish List for Adblock Plus.txt
@@ -1342,7 +1342,6 @@ ysektionen.se##.yweb-news-paper-banner
 ||applicationinsights.azure.com/*track
 ||apprl.com/embed/$subdocument
 ||appsmav.com^$third-party
-||apsis.one^$third-party
 ||arctic.nyheter24.se^*/heatmap.js
 ||ascontentcloud.com^$third-party
 ||assets.pinterest.com/js/pinit$third-party
@@ -1805,7 +1804,6 @@ ysektionen.se##.yweb-news-paper-banner
 ||top100ruokablogit.com^$third-party
 ||tourn.co^$third-party
 ||tourn.se^$third-party
-||tr.apsisforms.com^$third-party
 ||track.cpa.tpgrn.com^
 ||track.intersport.se^$xmlhttprequest
 ||track.postkodlotteriet.se^


### PR DESCRIPTION
Hello! I'm creating this pull request to ask that you take out APSIS domains from your list. 😊 
*Disclosure: I work for APSIS in Sweden.*

**A bit about APSIS**
APSIS is not an ad platform; we provide tools for marketers to track their own traffic and show their own content (e.g. newsletter forms) in a GDPR-compliant manner. We do not share this data with Google, Facebook or any other platform/vendor. In addition to that, our customers are not able to show ads from any vendor using our tools. Our terms of service prohibit our customers from using our tools in a way that violates privacy and data protection laws.

If you feel that there is another purpose (or concern) for keeping our domain on your list, please let me know. We might be able to address your concerns. Otherwise, please accept my pull request.

Thank you!

